### PR TITLE
Add version check to skip redundant reinstalls

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -32,6 +32,7 @@ function copyDirRecursive(src, dest) {
 function install() {
   const args = process.argv.slice(2);
   const isLocal = args.includes("--local");
+  const isForce = args.includes("--force");
 
   let targetBase;
   if (isLocal) {
@@ -43,17 +44,36 @@ function install() {
   const packageRoot = path.resolve(__dirname, "..");
   const commandsSrc = path.join(packageRoot, COMMANDS_DIR);
   const commandsDest = path.join(targetBase, COMMANDS_DIR);
+  const versionFile = path.join(commandsDest, ".version");
 
   if (!fs.existsSync(commandsSrc)) {
     console.error("Error: commands directory not found at", commandsSrc);
     process.exit(1);
   }
 
-  console.log("\n  claude-github-skills installer\n");
-  console.log(`  Installing to: ${targetBase}\n`);
+  const pkg = require(path.join(packageRoot, "package.json"));
+  const currentVersion = pkg.version;
+
+  // Check installed version
+  if (!isForce && fs.existsSync(versionFile)) {
+    const installedVersion = fs.readFileSync(versionFile, "utf-8").trim();
+    if (installedVersion === currentVersion) {
+      console.log(`\n  claude-github-skills v${currentVersion} is already up to date.\n`);
+      console.log("  Use --force to reinstall.\n");
+      return;
+    }
+    console.log(`\n  claude-github-skills installer\n`);
+    console.log(`  Updating from v${installedVersion} to v${currentVersion}\n`);
+  } else {
+    console.log("\n  claude-github-skills installer\n");
+    console.log(`  Installing v${currentVersion} to: ${targetBase}\n`);
+  }
 
   console.log("  Installing commands...");
   copyDirRecursive(commandsSrc, commandsDest);
+
+  // Write version file
+  fs.writeFileSync(versionFile, currentVersion, "utf-8");
 
   console.log("\n  Installation complete!");
   console.log("\n  Available commands:");

--- a/bin/install.js
+++ b/bin/install.js
@@ -56,14 +56,19 @@ function install() {
 
   // Check installed version
   if (!isForce && fs.existsSync(versionFile)) {
-    const installedVersion = fs.readFileSync(versionFile, "utf-8").trim();
-    if (installedVersion === currentVersion) {
-      console.log(`\n  claude-github-skills v${currentVersion} is already up to date.\n`);
-      console.log("  Use --force to reinstall.\n");
-      return;
+    try {
+      const installedVersion = fs.readFileSync(versionFile, "utf-8").trim();
+      if (installedVersion === currentVersion) {
+        console.log(`\n  claude-github-skills v${currentVersion} is already up to date.\n`);
+        console.log("  Use --force to reinstall.\n");
+        return;
+      }
+      console.log(`\n  claude-github-skills installer\n`);
+      console.log(`  Updating from v${installedVersion} to v${currentVersion}\n`);
+    } catch {
+      console.log("\n  claude-github-skills installer\n");
+      console.log(`  Installing v${currentVersion} to: ${targetBase}\n`);
     }
-    console.log(`\n  claude-github-skills installer\n`);
-    console.log(`  Updating from v${installedVersion} to v${currentVersion}\n`);
   } else {
     console.log("\n  claude-github-skills installer\n");
     console.log(`  Installing v${currentVersion} to: ${targetBase}\n`);


### PR DESCRIPTION
## Summary
Adds a version check to the installer so repeat `npx claude-github-skills@latest` runs skip the install if the skills are already up to date. Provides clear feedback about what's happening.

## Changes
- Write a `.version` file to the install destination after successful install
- On subsequent runs, compare installed version with current package version
- If versions match, print "already up to date" and exit early
- Add `--force` flag to override the version check and reinstall anyway
- Show "Updating from vX to vY" messaging when upgrading

Closes #5

---
Worked on with Claude Code