### PR TITLE
Add /gh:list command to display issues by priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Project-local install copies commands to `.claude/commands/gh/` in your current 
 1. Install the skills: `npx claude-github-skills@latest`
 2. Open your project in Claude Code
 3. Run `/gh:setup` to scope the skills to your repository
-4. Start using `/gh:work`, `/gh:review-pr`, or `/gh:fix-pr`
+4. Start using `/gh:work`, `/gh:review-pr`, `/gh:fix-pr`, or `/gh:list`
 
 ## Commands
 
@@ -84,6 +84,23 @@ What it does:
 7. For PRs with 15+ changed files, prioritizes core logic, largest diffs, and new files
 8. Optionally offers to run Playwright for visual regression checks on UI changes (only if Playwright is in the project)
 
+### `/gh:list [priority]` — List issues by priority
+
+Displays all open issues sorted by priority (critical → high → medium → low), with optional filtering.
+
+```
+/gh:list
+/gh:list critical
+```
+
+What it does:
+1. Reads project scope from `CLAUDE.md`
+2. Fetches open issues with priority labels (`priority:critical`, `priority:high`, `priority:medium`, `priority:low`)
+3. Groups and displays them in priority order with a formatted table (issue number, title, assignees, created date)
+4. Shows a summary count at the end
+5. Supports filtering to a single priority level — `/gh:list high` shows only high-priority issues
+6. Shows a helpful error for invalid priority arguments
+
 ### `/gh:fix-pr <pr#>` — Fix review feedback
 
 Reads all review comments on a PR and addresses each one.
@@ -121,7 +138,8 @@ claude-github-skills/
 │       ├── setup.md        # /gh:setup skill definition
 │       ├── work.md         # /gh:work skill definition
 │       ├── review-pr.md    # /gh:review-pr skill definition
-│       └── fix-pr.md       # /gh:fix-pr skill definition
+│       ├── fix-pr.md       # /gh:fix-pr skill definition
+│       └── list.md         # /gh:list skill definition
 ├── package.json
 └── README.md
 ```

--- a/bin/install.js
+++ b/bin/install.js
@@ -86,6 +86,7 @@ function install() {
   console.log("    /gh:work <#>    - Work on a GitHub issue");
   console.log("    /gh:review-pr <#> - Review a pull request");
   console.log("    /gh:fix-pr <#>  - Fix PR review feedback");
+  console.log("    /gh:list [priority] - List issues by priority");
   console.log("\n  Prerequisites:");
   console.log("    - GitHub CLI (gh) installed and authenticated");
   console.log("    - Run /gh:setup in your project first\n");

--- a/commands/gh/list.md
+++ b/commands/gh/list.md
@@ -1,0 +1,109 @@
+---
+name: gh:list
+description: List issues sorted by priority (critical → low), optionally filtered by priority level
+argument-hint: "[priority]"
+allowed-tools:
+  - Bash
+  - Read
+---
+
+<role>
+You are a project manager displaying GitHub issues organized by priority. You fetch issues from the scoped repository and present them in a clear, priority-ordered format.
+</role>
+
+<objective>
+Display all open issues sorted by priority (critical → high → medium → low), or filter to a single priority level if specified.
+</objective>
+
+<context>
+Priority argument: $ARGUMENTS
+</context>
+
+<process>
+
+## Step 1: Read project scope
+
+Read `CLAUDE.md` in the project root. Look for the `<!-- gh-skills-start -->` block to find the scoped `owner/repo`.
+
+If the block is missing, tell the user to run `/gh:setup` first and stop.
+
+## Step 2: Validate arguments
+
+The valid priority levels are: `critical`, `high`, `medium`, `low`.
+
+- If `$ARGUMENTS` is empty, proceed to fetch all priorities.
+- If `$ARGUMENTS` is one of the valid priority levels (case-insensitive), proceed to fetch only that priority.
+- If `$ARGUMENTS` is anything else, show this error and stop:
+
+> **Invalid priority: `$ARGUMENTS`**
+>
+> Supported levels: `critical`, `high`, `medium`, `low`
+>
+> Usage:
+> - `/gh:list` — all issues by priority
+> - `/gh:list critical` — only critical issues
+
+## Step 3: Fetch issues
+
+Use the GitHub CLI to fetch open issues with priority labels.
+
+Priority labels follow the format: `priority:critical`, `priority:high`, `priority:medium`, `priority:low`.
+
+**If a specific priority was requested**, fetch only that level:
+
+```bash
+gh issue list --repo owner/repo --label "priority:<level>" --state open --json number,title,labels,assignees,createdAt --limit 100
+```
+
+**If no priority was specified**, fetch all four levels. Run four separate commands (one per priority level) to keep them grouped:
+
+```bash
+gh issue list --repo owner/repo --label "priority:critical" --state open --json number,title,labels,assignees,createdAt --limit 100
+gh issue list --repo owner/repo --label "priority:high" --state open --json number,title,labels,assignees,createdAt --limit 100
+gh issue list --repo owner/repo --label "priority:medium" --state open --json number,title,labels,assignees,createdAt --limit 100
+gh issue list --repo owner/repo --label "priority:low" --state open --json number,title,labels,assignees,createdAt --limit 100
+```
+
+## Step 4: Format and display
+
+Present the issues in a clear, readable format grouped by priority level. Use this structure:
+
+```
+## 🔴 Critical
+| # | Title | Assignees | Created |
+|---|-------|-----------|---------|
+| 12 | Fix auth bypass | @alice | 2025-03-01 |
+
+## 🟠 High
+| # | Title | Assignees | Created |
+|---|-------|-----------|---------|
+| 8 | Add rate limiting | — | 2025-03-05 |
+
+## 🟡 Medium
+(no issues)
+
+## 🟢 Low
+| # | Title | Assignees | Created |
+|---|-------|-----------|---------|
+| 3 | Update README links | @bob | 2025-02-20 |
+```
+
+Rules:
+- Always show the priority header, even if there are no issues at that level — display "(no issues)" under it.
+- If filtering by a single priority, only show that one section.
+- If there are no issues at all, say: "No open issues found with priority labels."
+- Show assignee logins prefixed with `@`, or `—` if unassigned.
+- Format dates as `YYYY-MM-DD`.
+- At the end, show a summary line: `**Total: X issues** (Y critical, Z high, ...)`
+
+## Step 5: Suggest next steps
+
+After displaying the list, suggest:
+
+> Use `/gh:work <issue#>` to start working on an issue.
+
+If no issues have priority labels at all, also suggest:
+
+> Add priority labels (`priority:critical`, `priority:high`, `priority:medium`, `priority:low`) to your issues to use this command effectively.
+
+</process>


### PR DESCRIPTION
## Summary
Adds a new `/gh:list` command that displays open issues organized by priority level (critical → high → medium → low).

## Changes
- Added `commands/gh/list.md` — new skill that fetches issues by `priority:*` labels and displays them in formatted tables grouped by priority
- Updated `bin/install.js` to show `/gh:list` in available commands after install
- Updated `README.md` with full documentation for the new command, including quick start and file structure

Closes #8

---
Worked on with Claude Code