### PR TITLE
Add error handling and --verbose flag to install.js

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -5,12 +5,20 @@ const path = require("path");
 
 const COMMANDS_DIR = "commands/gh";
 
+const args = process.argv.slice(2);
+const verbose = args.includes("--verbose");
+
+function log(...msg) {
+  if (verbose) console.log("  [verbose]", ...msg);
+}
+
 function getClaudeHome() {
   const home = process.env.HOME || process.env.USERPROFILE;
   return path.join(home, ".claude");
 }
 
 function copyDirRecursive(src, dest) {
+  log("Creating directory:", dest);
   if (!fs.existsSync(dest)) {
     fs.mkdirSync(dest, { recursive: true });
   }
@@ -23,6 +31,7 @@ function copyDirRecursive(src, dest) {
     if (entry.isDirectory()) {
       copyDirRecursive(srcPath, destPath);
     } else {
+      log(`Copying: ${srcPath} -> ${destPath}`);
       fs.copyFileSync(srcPath, destPath);
       console.log(`  Copied: ${entry.name}`);
     }
@@ -30,7 +39,6 @@ function copyDirRecursive(src, dest) {
 }
 
 function install() {
-  const args = process.argv.slice(2);
   const isLocal = args.includes("--local");
   const isForce = args.includes("--force");
 
@@ -47,9 +55,18 @@ function install() {
   const versionFile = path.join(commandsDest, ".version");
 
   if (!fs.existsSync(commandsSrc)) {
-    console.error("Error: commands directory not found at", commandsSrc);
+    console.error(
+      `\n  Installation failed: source commands directory not found.\n` +
+      `  Expected location: ${commandsSrc}\n\n` +
+      `  This usually means the package was not downloaded correctly.\n` +
+      `  Try reinstalling the package and running this command again.\n`
+    );
     process.exit(1);
   }
+
+  log("Package root:", packageRoot);
+  log("Source:", commandsSrc);
+  log("Destination:", commandsDest);
 
   const pkg = require(path.join(packageRoot, "package.json"));
   const currentVersion = pkg.version;
@@ -74,11 +91,22 @@ function install() {
     console.log(`  Installing v${currentVersion} to: ${targetBase}\n`);
   }
 
-  console.log("  Installing commands...");
-  copyDirRecursive(commandsSrc, commandsDest);
+  try {
+    console.log("  Installing commands...");
+    copyDirRecursive(commandsSrc, commandsDest);
 
-  // Write version file
-  fs.writeFileSync(versionFile, currentVersion, "utf-8");
+    // Write version file
+    fs.writeFileSync(versionFile, currentVersion, "utf-8");
+  } catch (err) {
+    console.error(`\n  Installation failed: ${err.message}`);
+    if (err.code === "EACCES" || err.code === "EPERM") {
+      console.error("  Check that you have write permissions to:", targetBase);
+    } else if (err.code === "ENOSPC") {
+      console.error("  Disk is full. Free up space and try again.");
+    }
+    log("Stack trace:", err.stack);
+    process.exit(1);
+  }
 
   console.log("\n  Installation complete!");
   console.log("\n  Available commands:");


### PR DESCRIPTION
## Summary
Adds proper error handling to `bin/install.js` so users get clear, actionable error messages instead of raw Node.js stack traces when installation fails.

## Changes
- Wrapped `copyDirRecursive` and `install` in try/catch blocks with clear error messages
- Added contextual hints for permission (`EACCES`/`EPERM`) and disk space (`ENOSPC`) errors
- Added `--verbose` flag for debugging install issues (shows file paths and stack traces)
- Improved the missing source directory error to be user-friendly with remediation steps
- Ensured non-zero exit code on all failure paths

Closes #2

---
Worked on with Claude Code