### PR TITLE
Harden secrets protection and clean up .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# NPM token for publishing (get from npmjs.com → Access Tokens)
+# Do NOT commit real tokens — use GitHub Actions secrets for CI/CD
+NPM_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,11 @@ node_modules/
 *.log
 .DS_Store
 Thumbs.db
+# Environment and secrets
 .env
+.env.*
+!.env.example
+credentials.json
+secrets.json
+*.pem
+*.key


### PR DESCRIPTION
## Summary
Addresses the security concerns in issue #13. The `.env` file was never committed to git history (verified), and the user has already rotated the NPM token. This PR hardens the project against future secret leaks.

## Changes
- Expanded `.gitignore` with comprehensive secret file patterns (`.env.*`, `credentials.json`, `secrets.json`, `*.pem`, `*.key`)
- Added `.env.example` so contributors know which env vars are needed without exposing real values
- Excluded `.env.example` from gitignore via `!.env.example` negation pattern

## Notes
- `.env` was **never in git history** — verified via `git log --all --full-history -- .env` (empty)
- No `NPM_TOKEN` references found in history — verified via `git log -p --all -S 'NPM_TOKEN'` (empty)
- Token rotation was done manually by the repo owner prior to this PR
- The `.env` file has been deleted from the working directory

Closes #13

---
Worked on with Claude Code